### PR TITLE
add vulture static analyzer

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -136,6 +136,12 @@ matrix:
         #   stage: Initial tests
         #   env: TOXENV=codestyle
 
+       - os: linux
+          python: 3.8
+          name: unused code check
+          stage: Comprehensive tests
+          env: TOXENV=unused_code
+
 before_install:
     # Create a coverage.xml for use by coveralls or codecov
     - if [[ $TOXENV == *-cov ]]; then

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -91,3 +91,9 @@ changedir = .
 description = check code style, e.g. with flake8
 deps = flake8
 commands = flake8 {{ cookiecutter.module_name }} --count --max-line-length=100
+
+[testenv:unused_code]
+basepython=python
+deps = vulture
+changedir = .
+commands = vulture ./{{ cookiecutter.module_name }} --min-confidence=80 --exclude {{ cookiecutter.module_name }}/extern/


### PR DESCRIPTION
A static code analyzer. Thus can be run quickly on-device to check for code coverage and improve diffs.

https://stackoverflow.com/a/9824998/5041184
Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>